### PR TITLE
Fix RTC alarm timing for clock updates

### DIFF
--- a/firmware/apps/clock/__init__.py
+++ b/firmware/apps/clock/__init__.py
@@ -650,7 +650,8 @@ def update():
 
     # We then get the current time, and set an RTC alarm to wake up at the start of
     # the next minute and run all this again, so the clock can update.
-    rtc.set_alarm(minutes=1)
+    currentsecond = rtc.datetime()[5]
+    rtc.set_alarm(seconds=60-currentsecond)
     display_time()
 
     # Update the screen

--- a/firmware/apps/clock/__init__.py
+++ b/firmware/apps/clock/__init__.py
@@ -651,7 +651,7 @@ def update():
     # We then get the current time, and set an RTC alarm to wake up at the start of
     # the next minute and run all this again, so the clock can update.
     currentsecond = rtc.datetime()[5]
-    rtc.set_alarm(seconds=60-currentsecond)
+    rtc.set_alarm(seconds=60 - currentsecond)
     display_time()
 
     # Update the screen


### PR DESCRIPTION
Adjust RTC alarm to trigger at the start of the next minute.

This fixes the current behavior where the next screen update is scheduled 1 minute into the future, instead of at the start of the next minute.