### PR TITLE
Fix rectangle around title in thumbnail view

### DIFF
--- a/firmware/apps/gallery/__init__.py
+++ b/firmware/apps/gallery/__init__.py
@@ -135,10 +135,10 @@ def update():
         badge.mode(FAST_UPDATE | NON_BLOCKING)
         screen.pen = color.white
         screen.shape(shape.rectangle(
-            (screen.width / 2) - (width / 2) - 8, 1, width + 16, 17, 6))
+            (screen.width / 2) - (width / 2) - 8, 1, width + 16, 17))
         screen.pen = color.black
         screen.shape(shape.rectangle(
-            (screen.width / 2) - (width / 2) - 8, 1, width + 16, 17, 6).stroke(1))
+            (screen.width / 2) - (width / 2) - 8, 1, width + 16, 17).stroke(1))
         screen.text(title, (screen.width / 2) - (width / 2), 3)
 
     badge.update()


### PR DESCRIPTION
Fix for #24 .

Ensures that thumbnail view shows a white box with black border around image name.