### PR TITLE
powman: Retune PSRAM timing after the sleep clock drop.

### DIFF
--- a/modules/c/powman/micropython.cmake
+++ b/modules/c/powman/micropython.cmake
@@ -11,7 +11,7 @@ target_include_directories(usermod_sleep INTERFACE
     ${PICOVECTOR_DIR}   # picovector_working_buffer.h — the shared scratch pool reused as the parser arena
 )
 
-target_link_libraries(usermod_sleep INTERFACE hardware_powman hardware_gpio)
+target_link_libraries(usermod_sleep INTERFACE hardware_powman hardware_gpio hardware_psram)
 
 target_link_libraries(usermod INTERFACE usermod_sleep)
 

--- a/modules/c/powman/powman.c
+++ b/modules/c/powman/powman.c
@@ -120,10 +120,21 @@ void pcf85063_wakeup_init(uint8_t period) {
 void powman_init() {
     uint64_t abs_time_ms = 1746057600000; // 2025/05/01 - Milliseconds since epoch
 
+    // Never restored: PSRAM holds the MicroPython heap and is unmapped below, so no
+    // handler may run between here and the core powering off.
+    save_and_disable_interrupts();
+
     clear_double_tap_flag();
 
     // Run everything from pll_usb pll and stop pll_sys
     set_sys_clock_48mhz();
+
+    // QMI_M1_TIMING.MAX_SELECT bounds PSRAM CS-low in clk_sys cycles, so the drop above
+    // stretches it past the 8us the part allows. Re-derive it as machine.freq() does.
+    if (psram_is_available()) {
+        psram_configure_params(PICO_DEFAULT_PSRAM_MAX_FREQ, PICO_DEFAULT_PSRAM_MAX_SELECT, PICO_DEFAULT_PSRAM_MIN_DESELECT);
+        psram_reinitialize();
+    }
 
     // Set up GPIO for optimum power consumption
     for (int i = 0; i < NUM_BANK0_GPIOS; ++i) {

--- a/modules/c/powman/powman.h
+++ b/modules/c/powman/powman.h
@@ -19,6 +19,7 @@
 #include "hardware/i2c.h"
 #include "hardware/resets.h"
 #include "hardware/pwm.h"
+#include "hardware/psram.h"
 
 // For machine_pin_find
 #include "machine_pin.h"


### PR DESCRIPTION
powman_init() drops clk_sys to 48MHz before powering the core off. QMI_M1_TIMING MAX_SELECT bounds PSRAM CS-low in clk_sys cycles, so the drop stretches it from 7.9us to 41.3us, well past the 8us the APS6404 allows. The GC heap is entirely in PSRAM, so a heap read past that point returns garbage and the next dereference takes a precise bus fault, escalating to HardFault or lockup. The badge sleeps and wakes, then dies, which reads as a failure to wake.

Re-derive the timing the way machine.freq() does. At 150MHz the same stale value only reached 24us, and the split heap kept plenty of objects in SRAM, so this did not bite before the 250MHz overclock.

Interrupts stay off for the rest of powman_init(): PSRAM is unmapped a few lines later and no handler can safely run against it before the core powers off.

Fixes #28